### PR TITLE
 ✏️fix: start port 3000

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "set PORT=8888 && react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
### PR 타입
- [x] start시 포트번호 3000번으로 이동

### 반영 브랜치
NamgyungKim/develop -> pre-onboarding-team3/develop

### 변경 사항
LocalStorage 기능 안되는부분 수정
원인은 모르겠으나
"start": "set PORT=8888 && react-scripts start",
를 "react-scripts start" 로 변경해주니 해결됨